### PR TITLE
removes duplicate values from labels in jenks color scale

### DIFF
--- a/src/ColorScale.js
+++ b/src/ColorScale.js
@@ -77,7 +77,7 @@ export default class ColorScale extends BaseClass {
     this._group = elem("g.d3plus-ColorScale", {parent: this._select});
 
     const domain = extent(this._data, this._value);
-    let colors = this._color, ticks;
+    let colors = this._color, labels, ticks;
 
     if (!(colors instanceof Array)) {
       colors = [
@@ -109,6 +109,12 @@ export default class ColorScale extends BaseClass {
 
       ticks = merge(jenks.map((c, i) => i === jenks.length - 1 ? [c[0], c[c.length - 1]] : [c[0]]));
 
+      const tickSet = new Set(ticks);
+
+      if (ticks.length !== tickSet.size) {
+        labels = Array.from(tickSet);
+      }
+
       this._colorScale = scaleThreshold()
         .domain(ticks)
         .range(["black"].concat(colors).concat(colors[colors.length - 1]));
@@ -131,7 +137,7 @@ export default class ColorScale extends BaseClass {
       domain: horizontal ? domain : domain.reverse(),
       duration: this._duration,
       height: this._height,
-      labels: ticks,
+      labels: labels || ticks,
       orient: this._orient,
       padding: this._padding,
       ticks,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #65 )

### Description
<!--- Describe your changes in detail -->
The bug of missing labels in the `jenks` color scale was caused by duplicate values in the [ticks array in ColorScale.js](https://github.com/d3plus/d3plus-legend/blob/master/src/ColorScale.js#L110). To ensure that all labels are rendered, I created a `labels` variable which is initialized to the unique values in `ticks` if it contains duplicates.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

