### PR TITLE
replaces labelPadding with padding in labelConfig

### DIFF
--- a/src/Legend.js
+++ b/src/Legend.js
@@ -335,7 +335,7 @@ export default class Legend extends BaseClass {
       this._shapes.push(new shapes[Shape]()
         .data(data.filter(d => d.shape === Shape))
         .duration(this._duration)
-        .labelPadding(0)
+        .labelConfig({padding: 0})
         .select(this._group.node())
         .verticalAlign("top")
         .config(assign({}, baseConfig, config))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### Description
<!--- Describe your changes in detail -->
[This reference to the `labelPadding` method](https://github.com/d3plus/d3plus-legend/blob/master/src/Legend.js#L338) was breaking Legend. I replaced it with `padding` in `labelConfig`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

