### PR TITLE
fixes d3plus/d3plus-viz#86

### DIFF
--- a/src/ckmeans.js
+++ b/src/ckmeans.js
@@ -146,7 +146,7 @@ function fillMatrixColumn(iMin, iMax, cluster, matrix, backtrackMatrix, sums, su
     @param {Array<Array<number>>} backtrackMatrix
 */
 function fillMatrices(data, matrix, backtrackMatrix) {
-  const nValues = matrix[0].length;
+  const nValues = matrix[0] ? matrix[0].length : 0;
 
   // Shift values by the median to improve numeric stability
   const shift = data[Math.floor(nValues / 2)];
@@ -156,7 +156,7 @@ function fillMatrices(data, matrix, backtrackMatrix) {
   const sumsOfSquares = [];
 
   // Initialize first column in matrix & backtrackMatrix
-  for (let i = 0, shiftedValue; i < nValues; ++i) {
+  for (let i = 0, shiftedValue = void 0; i < nValues; ++i) {
     shiftedValue = data[i] - shift;
     if (i === 0) {
       sums.push(shiftedValue);
@@ -216,7 +216,9 @@ export default function(data, nClusters) {
   const uniqueCount = uniqueCountSorted(sorted);
 
   // if all of the input values are identical, there's one cluster with all of the input in it.
-  if (uniqueCount === 1) return [sorted];
+  if (uniqueCount === 1) {
+    return [sorted];
+  }
 
   const backtrackMatrix = makeMatrix(nClusters, sorted.length),
         matrix = makeMatrix(nClusters, sorted.length);
@@ -225,7 +227,7 @@ export default function(data, nClusters) {
   fillMatrices(sorted, matrix, backtrackMatrix);
 
   // The real work of Ckmeans clustering happens in the matrix generation: the generated matrices encode all possible clustering combinations, and once they're generated we can solve for the best clustering groups very quickly.
-  let clusterRight = backtrackMatrix[0].length - 1;
+  let clusterRight = backtrackMatrix[0] ? backtrackMatrix[0].length - 1 : 0;
   const clusters = [];
 
   // Backtrack the clusters from the dynamic programming matrix. This starts at the bottom-right corner of the matrix (if the top-left is 0, 0), and moves the cluster target with the loop.


### PR DESCRIPTION
Fix [d3plus/d3plus-viz#86](https://github.com/d3plus/d3plus-viz/issues/86)

### Description
The bug was caused because `matrix` and `backtrackMatrix` are `undefined` where you use `jenks` and `data = []`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

