### PR TITLE
includes new property called groupBy as legend attribute

### DIFF
--- a/src/Legend.js
+++ b/src/Legend.js
@@ -31,6 +31,7 @@ export default class Legend extends BaseClass {
     this._direction = "row";
     this._duration = 600;
     this._height = 200;
+    this._groupBy = accessor("id");
     this._id = accessor("id");
     this._label = accessor("id");
     this._lineData = [];
@@ -434,6 +435,16 @@ export default class Legend extends BaseClass {
   hover(_) {
     this._shapes.forEach(s => s.hover(_));
     return this;
+  }
+
+  /**
+      @memberof Legend
+      @desc If *value* is specified, sets the groupBy accessor to the specified function and returns the current class instance. If *value* is not specified, returns the current groupBy accessor, which is the [id](#shape.id) accessor by default.
+      @param {Function} [*value*]
+      @chainable
+  */
+  _groupBy(_) {
+    return arguments.length ? (this._groupBy = _, this) : this._groupBy;
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### Description
<!--- Describe your changes in detail -->
Sometimes it's necessary on `d3plus.viz` to have access to the current groupBy used by the viz  inside the legend. This PR includes `groupBy` attribute.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

