### PR TITLE
adds centered param to allow midpoint centered axis

### DIFF
--- a/src/ColorScale.js
+++ b/src/ColorScale.js
@@ -50,7 +50,7 @@ export default class ColorScale extends BaseClass {
     this._align = "middle";
     this._buckets = 5;
     this._bucketAxis = false;
-    this._centered = false;
+    this._centered = true;
     this._colorMax = "#0C8040";
     this._colorMid = "#f7f7f7";
     this._colorMin = "#b22200";
@@ -126,26 +126,28 @@ export default class ColorScale extends BaseClass {
 
       const buckets = min([colors ? colors.length : this._buckets, data.length]);
 
-      var jenks = [];
+      let jenks = [];
 
       if (diverging && this._centered) {
-        var half = Math.floor(buckets / 2);
-        var residual = buckets % 2;
-
-        var negatives = data.filter(d => d < this._midpoint);
-        var negativesDeviation = deviation(negatives);
-
-        var positives = data.concat(this._midpoint).filter(d => d >= this._midpoint);
-        var positivesDeviation = deviation(positives);
-
-        var isNegativeMax = negativesDeviation > positivesDeviation ? 1 : 0;
-        var isPositiveMax = positivesDeviation > negativesDeviation ? 1 : 0;
         
-        var negativeJenks = ckmeans(negatives, half + residual * isNegativeMax);
-        var positiveJenks = ckmeans(positives, half + residual * isPositiveMax);
+        const half = Math.floor(buckets / 2);
+        const residual = buckets % 2;
+
+        const negatives = data.filter(d => d < this._midpoint);
+        const negativesDeviation = deviation(negatives);
+
+        const positives = data.concat(this._midpoint).filter(d => d >= this._midpoint);
+        const positivesDeviation = deviation(positives);
+
+        const isNegativeMax = negativesDeviation > positivesDeviation ? 1 : 0;
+        const isPositiveMax = positivesDeviation > negativesDeviation ? 1 : 0;
+        
+        const negativeJenks = ckmeans(negatives, half + residual * isNegativeMax);
+        const positiveJenks = ckmeans(positives, half + residual * isPositiveMax);
         
         jenks = negativeJenks.concat(positiveJenks);
-      } else {
+      } 
+      else {
         jenks = ckmeans(data, buckets);
       }
 
@@ -222,18 +224,17 @@ export default class ColorScale extends BaseClass {
           buckets = range(0, 1 + step / 2, step)
             .map(d => quantile(allValues, d));
         }
-        else {
-          if ((this._scale === "linear" || this._scale === "log") && diverging && this._color && this._centered) {
-            const negativeStep = ((this._midpoint - domain[0]) / Math.floor(colors.length / 2));
-            const positiveStep = ((domain[1] - this._midpoint) / Math.floor(colors.length / 2));
-            const negativeBuckets = range(domain[0], this._midpoint, negativeStep);
-            const positiveBuckets = range(this._midpoint, domain[1] + positiveStep / 2, positiveStep);
+        else if (diverging && this._color && this._centered) {
+          const negativeStep = (this._midpoint - domain[0]) / Math.floor(colors.length / 2);
+          const positiveStep = (domain[1] - this._midpoint) / Math.floor(colors.length / 2);
+          const negativeBuckets = range(domain[0], this._midpoint, negativeStep);
+          const positiveBuckets = range(this._midpoint, domain[1] + positiveStep / 2, positiveStep);
 
-            buckets = negativeBuckets.concat(positiveBuckets);
-          } else {
-            const step = (domain[1] - domain[0]) / (colors.length - 1);
-            buckets = range(domain[0], domain[1] + step / 2, step);
-          }
+          buckets = negativeBuckets.concat(positiveBuckets);
+        } 
+        else {
+          const step = (domain[1] - domain[0]) / (colors.length - 1);
+          buckets = range(domain[0], domain[1] + step / 2, step);
         }
       }
 
@@ -513,12 +514,13 @@ export default class ColorScale extends BaseClass {
   bucketAxis(_) {
     return arguments.length ? (this._bucketAxis = _, this) : this._bucketAxis;
   }
-      /**
+
+  /**
       @memberof ColorScale
-      @desc Determines whether or not to display a midpoint centered Axis. Works on linear, log and jenks scales.
+      @desc Determines whether or not to display a midpoint centered Axis. Does not apply to quantile scales.
       @param {Boolean} [*value* = false]
       @chainable
-      */
+  */
 
   centered(_) {
     return arguments.length ? (this._centered = _, this) : this._centered;


### PR DESCRIPTION
adds a centered parameter to allow an axis centered at the midpoint

### Description
This PR adds a `centered` boolean param to d3plus Color Scale to allow to center the colorScale in the midpoint defined (or 0 if not) when we define a `color` scale instead `colorMin`, `colorMid` and `colorMax` methods.

### Types of changes
- [x] Adds a jenks centered option to apply kmeans algorithm to build possitive and negative buckets
- [x] Modifies `log` and `linear` scales behavior when we define a `color` scale

